### PR TITLE
Make periodic gc configurable

### DIFF
--- a/config/600-tekton-pruner-default-spec.yaml
+++ b/config/600-tekton-pruner-default-spec.yaml
@@ -5,6 +5,8 @@ metadata:
   name: tekton-pruner-default-spec
   namespace: tekton-pipelines
 data:
+  periodicCleanupEnabled: "true"
+  periodicCleanupIntervalSeconds: "300" #5 minutes
   global-config: |
     enforcedConfigLevel: global
     ttlSecondsAfterFinished: 300

--- a/config/config-info.yaml
+++ b/config/config-info.yaml
@@ -27,4 +27,3 @@ data:
   # other resources in the namespace we still can have access to
   # this ConfigMap.
   version: "devel"
-  gcIntervalSeconds: "300" #10 minutes

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -48,4 +48,4 @@ data:
 
   # Log level overrides
   # Changes are be picked up immediately.
-  loglevel.tekton-pruner-controller: "debug"
+  loglevel.tekton-pruner-controller: "info"

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -94,12 +94,8 @@ const (
 	DefaultTTLConcurrentWorkersTaskRun = int(5)
 
 	// DefaultGCInterval represents
-	// number of workers in the TaskRun controller
-	DefaultGCIntervalSeconds = 600 // 10 minutes
-
-	// PrunerControllerConfigMapName represents the name of the config map
-	// that holds the cluster-wide pruner configuration data
-	PrunerControllerConfigMapName = "pruner-info"
+	// interval in seconds for the periodic cleanup i.e garbage collector to run
+	DefaultPeriodicCleanupIntervalSeconds = 600 // 10 minutes
 )
 
 // GetEnvValueAsInt fetches the value of an environment variable and converts it to an integer


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Introduced 2 new configmap keys `periodicCleanupEnabled` and  `periodicCleanupIntervalSeconds` to capture user intention for periodic cleanup to remove unprocessed PRs/TRs that could be because unexpected pruner pod crash or pruner config updates leaving way for edge cases.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
