### PR TITLE
includes service definition to expose metrics port 9090

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -19,16 +19,34 @@ metadata:
   name: tekton-pruner-controller
   namespace: tekton-pipelines
   labels:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: tekton-pruner
     pruner.tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: controller
+      app: tekton-pruner-controller
+      app.kubernetes.io/name: controller
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-pruner
   template:
     metadata:
       labels:
-        app: controller
+        app: tekton-pruner-controller
+        app.kubernetes.io/name: controller
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/version: "devel"
+        app.kubernetes.io/part-of: tekton-pruner
+        # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
+        pipeline.tekton.dev/release: "devel"
+        # labels below are related to istio and should not be used for resource lookup
+        version: "devel"
         pruner.tekton.dev/release: "devel"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -39,6 +57,10 @@ spec:
                 labelSelector:
                   matchLabels:
                     app: controller
+                    app.kubernetes.io/name: controller
+                    app.kubernetes.io/component: controller
+                    app.kubernetes.io/instance: default
+                    app.kubernetes.io/part-of: tekton-pruner
                 topologyKey: kubernetes.io/hostname
               weight: 100
 
@@ -83,3 +105,32 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: tekton-pruner
+    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
+    pruner.tekton.dev/release: "devel"
+    # labels below are related to istio and should not be used for resource lookup
+    app: tekton-pruner-controller
+    version: "devel"
+  name: tekton-pruner-controller
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pruner

--- a/hack/setup-observability-simple.sh
+++ b/hack/setup-observability-simple.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# setup-observability-simple.sh - Simple observability setup for Tekton Pruner
+# This script sets up a Kind cluster with Tekton Pruner, Prometheus, and Jaeger for observability.
+# Services are accessed via port-forward for simplicity.
+# It assumes you have `kind`, `kubectl`, and `ko` installed and configured.
+
+set -euo pipefail
+
+# Configuration
+: "${KO_DOCKER_REPO:=<quay.io/some-repo>}" # Replace with your own repositorys
+: "${KIND_CLUSTER_NAME:=tekton-obs}"
+
+wait_for_deploy() {
+  local ns="$1"
+  local name="$2"
+  echo "Waiting for deployment $name in namespace $ns..."
+  for i in {1..60}; do
+    if kubectl -n "$ns" get deploy "$name" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 2
+  done
+  kubectl -n "$ns" rollout status deploy/"$name" --timeout=300s
+}
+
+setup_port_forwards() {
+  echo "Setting up port forwards..."
+  
+  # Kill any existing port-forwards
+  pkill -f "kubectl.*port-forward" || true
+  sleep 2
+  
+  # Setup port forwards in background
+  kubectl port-forward -n monitoring svc/prometheus 9091:9090 > /dev/null 2>&1 &
+  kubectl port-forward -n observability-system svc/jaeger 16686:16686 > /dev/null 2>&1 &
+  kubectl port-forward -n tekton-pipelines svc/tekton-pruner-controller 9090:9090 > /dev/null 2>&1 &
+  
+  echo "Port forwards started in background"
+}
+
+echo "Setting up observability stack..."
+
+# Create Kind cluster configuration
+cat > kind-config.yaml << EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.32.0
+EOF
+
+# Create Kind cluster
+echo "Creating Kind cluster..."
+kind create cluster --config kind-config.yaml --name "${KIND_CLUSTER_NAME}"
+
+# Install Tekton Pipeline
+echo "Installing Tekton Pipeline..."
+kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+wait_for_deploy tekton-pipelines tekton-pipelines-controller
+
+# Install Prometheus
+echo "Installing Prometheus..."
+kubectl apply -f - << EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+    - job_name: 'tekton-pruner'
+      static_configs:
+      - targets: ['tekton-pruner-controller.tekton-pipelines.svc.cluster.local:9090']
+    - job_name: 'kubernetes-pods'
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [tekton-pipelines]
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:latest
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+        args:
+        - '--config.file=/etc/prometheus/prometheus.yml'
+        - '--storage.tsdb.path=/prometheus'
+        - '--web.console.libraries=/etc/prometheus/console_libraries'
+        - '--web.console.templates=/etc/prometheus/consoles'
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090
+  type: ClusterIP
+EOF
+
+wait_for_deploy monitoring prometheus
+
+# Install Jaeger
+echo "Installing Jaeger..."
+kubectl apply -f - << EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: observability-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+      - name: jaeger
+        image: jaegertracing/all-in-one:latest
+        ports:
+        - containerPort: 16686
+        - containerPort: 14268
+        env:
+        - name: COLLECTOR_OTLP_ENABLED
+          value: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: observability-system
+spec:
+  selector:
+    app: jaeger
+  ports:
+  - name: ui
+    port: 16686
+    targetPort: 16686
+  - name: collector
+    port: 14268
+    targetPort: 14268
+  type: ClusterIP
+EOF
+
+wait_for_deploy observability-system jaeger
+
+# Deploy observability configuration
+echo "Deploying observability configuration..."
+kubectl apply -f - << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability-tekton-pruner
+  namespace: tekton-pipelines
+data:
+  metrics.backend-destination: "prometheus"
+  tracing.backend: "jaeger"
+  tracing.endpoint: "http://jaeger.observability-system.svc.cluster.local:14268/api/traces"
+EOF
+
+# Deploy Tekton Pruner (includes observability service)
+echo "Building and deploying Tekton Pruner..."
+export KO_DOCKER_REPO
+ko apply -f config/
+
+# Wait for deployments
+echo "Waiting for all services to be ready..."
+wait_for_deploy tekton-pipelines tekton-pruner-controller
+wait_for_deploy monitoring prometheus
+wait_for_deploy observability-system jaeger
+
+# Setup port forwards
+setup_port_forwards
+
+echo "Setup complete!"
+echo ""
+echo "Access URLs (via port-forward):"
+echo "  Prometheus: http://localhost:9091"
+echo "  Jaeger: http://localhost:16686"
+echo "  Pruner Metrics: http://localhost:9090/metrics"
+echo ""
+echo "Test metrics:"
+echo "  curl http://localhost:9090/metrics | grep -E 'tektoncd_pruner_'"
+echo ""
+echo "Troubleshooting:"
+echo "  kubectl logs -n tekton-pipelines -l app.kubernetes.io/name=controller"
+echo "  kubectl get endpoints -n tekton-pipelines tekton-pruner-controller"
+echo ""
+echo "Note: Port forwards are running in background. To stop them:"
+echo "  pkill -f 'kubectl.*port-forward'"

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.32.0


### PR DESCRIPTION
This pull request introduces 
- An explicit service definition for the pruner controller to expose metrics on port 9090. **NOTE**: The metrics exposed in this PR are the default knative controller metrics with knative pkg `knative.dev/pkg v0.0.0-20240708181110-b4e5f07a2c37` 
<img width="1056" height="102" alt="Screenshot From 2025-08-15 01-25-06" src="https://github.com/user-attachments/assets/997b3945-e115-4c42-948c-7487a76386f2" />

- Also includes a simple, reproducible environment for observability using Kind, Prometheus, and Jaeger with script `hack/setup-observability-simple.sh` 

**Observability and Environment Setup:**

* Added a new script `hack/setup-observability-simple.sh` that automates the creation of a Kind cluster and installs Tekton Pruner, Prometheus, and Jaeger, including port-forwarding for local access and troubleshooting commands.
* Introduced a default Kind cluster configuration in `kind-config.yaml` to ensure consistent local development environments.

**Kubernetes Resource Labeling and Service Definition:**

* Standardized and expanded Kubernetes labels in `config/controller.yaml` for the controller deployment, selectors, and pod templates, improving resource identification and compatibility with ecosystem tools. 
* Added a new `Service` definition for `tekton-pruner-controller` in `config/controller.yaml` to expose metrics on port 9090 and facilitate integration with Prometheus and other monitoring tools.# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
Includes a new service `tekton-pruner-controller`
 that exposes the metrics on port 9090. 
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
