### PR TITLE
add pruner specific metrics in OTEL format

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,279 @@
+# Tekton Pruner Metrics Documentation
+
+This document describes the comprehensive observability metrics exposed by the Tekton Pruner controller using OpenTelemetry. These metrics are exposed on port 9090 alongside Knative's built-in system metrics.
+
+## Metrics Overview
+
+The Tekton Pruner exposes metrics in the following categories:
+- **Resource Processing**: Track resource processing and deletion operations
+- **Performance Timing**: Monitor reconciliation and processing durations
+- **State Tracking**: Current state of active and pending resources
+- **Error Monitoring**: Detailed error tracking with classification
+- **Resource Age Analysis**: Understanding resource lifecycle patterns
+
+## Metrics Reference
+
+### Resource Processing Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `tektoncd_pruner_resources_processed_total` | Counter | Total number of Tekton resources processed by the pruner | `namespace`, `resource_type`, `status` |
+| `tektoncd_pruner_resources_deleted_total` | Counter | Total number of Tekton resources deleted by the pruner | `namespace`, `resource_type`, `operation` |
+| `tektoncd_pruner_resources_errors_total` | Counter | Total number of errors encountered while processing Tekton resources | `namespace`, `resource_type`, `error_type`, `reason` |
+
+### Performance Timing Metrics
+
+| Metric Name | Type | Description | Labels | Buckets |
+|-------------|------|-------------|--------|---------|
+| `tektoncd_pruner_reconciliation_duration_seconds` | Histogram | Time spent in reconciliation loops | `namespace`, `resource_type` | 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0 |
+| `tektoncd_pruner_ttl_processing_duration_seconds` | Histogram | Time spent processing TTL-based pruning | `namespace`, `resource_type`, `operation` | 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0 |
+| `tektoncd_pruner_history_processing_duration_seconds` | Histogram | Time spent processing history-based pruning | `namespace`, `resource_type`, `operation` | 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0 |
+
+### State Tracking Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `tektoncd_pruner_active_resources_count` | UpDownCounter | Current number of active Tekton resources being tracked | `namespace`, `resource_type` |
+| `tektoncd_pruner_pending_deletions_count` | UpDownCounter | Current number of resources pending deletion | `namespace`, `resource_type` |
+
+### Resource Age Analysis Metrics
+
+| Metric Name | Type | Description | Labels | Buckets |
+|-------------|------|-------------|--------|---------|
+| `tektoncd_pruner_resource_age_at_deletion_seconds` | Histogram | Age of resources when they are deleted | `namespace`, `resource_type`, `operation` | 60, 300, 600, 1800, 3600, 7200, 14400, 28800, 86400, 172800, 345600, 604800 |
+
+## Label Values
+
+### Resource Types
+- `pipelinerun`: Tekton PipelineRun resources
+- `taskrun`: Tekton TaskRun resources
+
+### Operations
+- `ttl`: TTL-based pruning operations
+- `history`: History-based pruning operations
+
+### Status Values
+- `success`: Successful operation
+- `failed`: Failed operation
+- `error`: Error occurred during operation
+
+### Error Types
+- `api_error`: Kubernetes API errors
+- `timeout`: Timeout-related errors
+- `validation`: Validation errors
+- `internal`: Internal processing errors
+- `not_found`: Resource not found errors
+- `permission`: Permission/authorization errors
+
+## Useful PromQL Queries
+
+### Resource Processing Analysis
+
+#### Overall Resource Processing Rate
+```promql
+# Total resources processed per second across all namespaces
+rate(tektoncd_pruner_resources_processed_total[5m])
+
+# Resources processed by type
+sum(rate(tektoncd_pruner_resources_processed_total[5m])) by (resource_type)
+
+# Resources processed by namespace
+sum(rate(tektoncd_pruner_resources_processed_total[5m])) by (namespace)
+```
+
+#### Resource Deletion Rates
+```promql
+# Total deletion rate across all operations
+rate(tektoncd_pruner_resources_deleted_total[5m])
+
+# Deletion rate by operation type (TTL vs History)
+sum(rate(tektoncd_pruner_resources_deleted_total[5m])) by (operation)
+
+# Deletion rate by resource type
+sum(rate(tektoncd_pruner_resources_deleted_total[5m])) by (resource_type)
+
+# Namespace-specific deletion patterns
+sum(rate(tektoncd_pruner_resources_deleted_total[5m])) by (namespace, resource_type)
+```
+
+### Performance Monitoring
+
+#### Reconciliation Performance
+```promql
+# Average reconciliation duration by resource type
+histogram_quantile(0.95, rate(tektoncd_pruner_reconciliation_duration_seconds_bucket[5m])) by (resource_type)
+
+# Slow reconciliation loops (> 1 second)
+histogram_quantile(0.99, rate(tektoncd_pruner_reconciliation_duration_seconds_bucket[5m])) > 1
+
+# Reconciliation duration trends
+increase(tektoncd_pruner_reconciliation_duration_seconds_sum[5m]) / increase(tektoncd_pruner_reconciliation_duration_seconds_count[5m])
+```
+
+#### Processing Duration Analysis
+```promql
+# TTL processing performance
+histogram_quantile(0.95, rate(tektoncd_pruner_ttl_processing_duration_seconds_bucket[5m])) by (namespace)
+
+# History processing performance
+histogram_quantile(0.95, rate(tektoncd_pruner_history_processing_duration_seconds_bucket[5m])) by (namespace)
+
+# Compare TTL vs History processing efficiency
+histogram_quantile(0.95, rate(tektoncd_pruner_ttl_processing_duration_seconds_bucket[5m])) by (operation)
+```
+
+### Error Monitoring
+
+#### Error Rate Analysis
+```promql
+# Overall error rate
+rate(tektoncd_pruner_resources_errors_total[5m])
+
+# Error rate by type
+sum(rate(tektoncd_pruner_resources_errors_total[5m])) by (error_type)
+
+# Critical errors requiring attention
+rate(tektoncd_pruner_resources_errors_total{error_type=~"api_error|permission"}[5m])
+
+# Error ratio compared to successful operations
+rate(tektoncd_pruner_resources_errors_total[5m]) / rate(tektoncd_pruner_resources_processed_total[5m])
+```
+
+#### Error Troubleshooting
+```promql
+# Errors by namespace (identify problematic namespaces)
+sum(rate(tektoncd_pruner_resources_errors_total[5m])) by (namespace)
+
+# Errors by reason (identify common failure patterns)
+sum(rate(tektoncd_pruner_resources_errors_total[5m])) by (reason)
+
+# Recent error spikes
+increase(tektoncd_pruner_resources_errors_total[1h]) > 10
+```
+
+### Resource Age and Lifecycle Analysis
+
+#### Resource Age Patterns
+```promql
+# Average age of deleted resources
+histogram_quantile(0.50, rate(tektoncd_pruner_resource_age_at_deletion_seconds_bucket[5m]))
+
+# Resources deleted within 1 hour vs older resources
+sum(rate(tektoncd_pruner_resource_age_at_deletion_seconds_bucket{le="3600"}[5m])) / sum(rate(tektoncd_pruner_resource_age_at_deletion_seconds_count[5m]))
+
+# Very old resources being cleaned up (> 1 week)
+histogram_quantile(0.95, rate(tektoncd_pruner_resource_age_at_deletion_seconds_bucket[5m])) > 604800
+```
+
+#### TTL vs History Cleanup Patterns
+```promql
+# Compare resource age at deletion between TTL and history operations
+histogram_quantile(0.95, rate(tektoncd_pruner_resource_age_at_deletion_seconds_bucket[5m])) by (operation)
+
+# TTL effectiveness (resources deleted close to their TTL expiry)
+histogram_quantile(0.50, rate(tektoncd_pruner_resource_age_at_deletion_seconds_bucket{operation="ttl"}[5m]))
+```
+
+### State and Capacity Monitoring
+
+#### Current Resource State
+```promql
+# Current active resources by type
+tektoncd_pruner_active_resources_count by (resource_type)
+
+# Resources pending deletion
+tektoncd_pruner_pending_deletions_count
+
+# Resource accumulation rate (if positive, resources are accumulating faster than being cleaned)
+rate(tektoncd_pruner_active_resources_count[5m])
+```
+
+#### Capacity Planning
+```promql
+# Growth trend of active resources
+deriv(tektoncd_pruner_active_resources_count[1h])
+
+# Backlog of resources pending deletion
+sum(tektoncd_pruner_pending_deletions_count) by (namespace)
+
+# Processing vs accumulation rate
+rate(tektoncd_pruner_resources_processed_total[5m]) - rate(tektoncd_pruner_active_resources_count[5m])
+```
+
+## Alerting Rules Examples
+
+### Critical Alerts
+```yaml
+groups:
+- name: tekton-pruner-critical
+  rules:
+  - alert: TektonPrunerHighErrorRate
+    expr: rate(tektoncd_pruner_resources_errors_total[5m]) / rate(tektoncd_pruner_resources_processed_total[5m]) > 0.1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "High error rate in Tekton Pruner"
+      description: "Error rate is {{ $value | humanizePercentage }} for namespace {{ $labels.namespace }}"
+
+  - alert: TektonPrunerProcessingStalled
+    expr: rate(tektoncd_pruner_resources_processed_total[10m]) == 0 and tektoncd_pruner_active_resources_count > 0
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Tekton Pruner processing has stalled"
+      description: "No resources processed in 10 minutes despite active resources present"
+```
+
+### Warning Alerts
+```yaml
+  - alert: TektonPrunerSlowReconciliation
+    expr: histogram_quantile(0.95, rate(tektoncd_pruner_reconciliation_duration_seconds_bucket[5m])) > 5
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Slow Tekton Pruner reconciliation"
+      description: "95th percentile reconciliation duration is {{ $value }}s"
+
+  - alert: TektonPrunerResourceAccumulation
+    expr: deriv(tektoncd_pruner_active_resources_count[1h]) > 100
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Resources accumulating faster than being pruned"
+      description: "Resource count growing at {{ $value }} per hour in namespace {{ $labels.namespace }}"
+```
+
+## Dashboard Recommendations
+
+### Key Panels for Monitoring Dashboard
+
+1. **Resource Processing Overview**
+   - Total resources processed (counter)
+   - Resources deleted by operation type (stacked area chart)
+   - Processing rate trends (line graph)
+
+2. **Performance Metrics**
+   - Reconciliation duration percentiles (heatmap)
+   - TTL vs History processing duration comparison (histogram)
+   - Processing efficiency trends (gauge)
+
+3. **Error Analysis**
+   - Error rate by type (pie chart)
+   - Error trends over time (line graph)
+   - Error distribution by namespace (bar chart)
+
+4. **Resource Lifecycle**
+   - Resource age at deletion distribution (histogram)
+   - Active vs pending resources (gauge)
+   - Resource accumulation trends (area chart)
+
+5. **Operational Health**
+   - Current error rate (single stat)
+   - Processing rate (single stat)
+   - Pending deletions count (single stat)
+
+This metrics implementation provides comprehensive observability into the Tekton Pruner's operations, enabling effective monitoring, troubleshooting, and capacity planning.

--- a/pkg/config/ttl_handler.go
+++ b/pkg/config/ttl_handler.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/openshift-pipelines/tektoncd-pruner/pkg/metrics"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -259,12 +260,34 @@ func (th *TTLHandler) removeResource(ctx context.Context, resource metav1.Object
 		"expiredAt", expiredAt,
 	)
 
+	// Calculate resource age for metrics
+	var resourceAge time.Duration
+	creationTime := resource.GetCreationTimestamp()
+	if !creationTime.IsZero() {
+		resourceAge = time.Since(creationTime.Time)
+	}
+
+	// Get resource type for metrics
+	resourceType := metrics.ResourceTypePipelineRun
+	if th.resourceFn.Type() == KindTaskRun {
+		resourceType = metrics.ResourceTypeTaskRun
+	}
+
 	if err := th.resourceFn.Delete(ctx, resource.GetNamespace(), resource.GetName()); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
+		// Record deletion error
+		metricsRecorder := metrics.GetRecorder()
+		errorType := metrics.ClassifyError(err)
+		metricsRecorder.RecordResourceError(ctx, resourceType, resource.GetNamespace(), errorType, "ttl_deletion_failed")
 		return fmt.Errorf("failed to delete resource: %w", err)
 	}
+
+	// Record successful deletion
+	metricsRecorder := metrics.GetRecorder()
+	metricsRecorder.RecordResourceDeleted(ctx, resourceType, resource.GetNamespace(), metrics.OperationTTL, resourceAge)
+
 	return nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,338 @@
+/*
+Copyright 2025 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	// Metric names
+	MetricResourcesProcessed        = "tektoncd_pruner_resources_processed_total"
+	MetricResourcesDeleted          = "tektoncd_pruner_resources_deleted_total"
+	MetricResourcesErrors           = "tektoncd_pruner_resources_errors_total"
+	MetricReconciliationDuration    = "tektoncd_pruner_reconciliation_duration_seconds"
+	MetricTTLProcessingDuration     = "tektoncd_pruner_ttl_processing_duration_seconds"
+	MetricHistoryProcessingDuration = "tektoncd_pruner_history_processing_duration_seconds"
+	MetricActiveResourcesCount      = "tektoncd_pruner_active_resources_count"
+	MetricPendingDeletionsCount     = "tektoncd_pruner_pending_deletions_count"
+	MetricResourceAgeAtDeletion     = "tektoncd_pruner_resource_age_at_deletion_seconds"
+
+	// Label keys
+	LabelNamespace    = "namespace"
+	LabelResourceType = "resource_type"
+	LabelStatus       = "status"
+	LabelReason       = "reason"
+	LabelErrorType    = "error_type"
+	LabelOperation    = "operation"
+
+	// Label values for resource types
+	ResourceTypePipelineRun = "pipelinerun"
+	ResourceTypeTaskRun     = "taskrun"
+
+	// Label values for operations
+	OperationTTL     = "ttl"
+	OperationHistory = "history"
+
+	// Label values for status
+	StatusSuccess = "success"
+	StatusFailed  = "failed"
+	StatusError   = "error"
+
+	// Label values for error types
+	ErrorTypeAPI        = "api_error"
+	ErrorTypeTimeout    = "timeout"
+	ErrorTypeValidation = "validation"
+	ErrorTypeInternal   = "internal"
+	ErrorTypeNotFound   = "not_found"
+	ErrorTypePermission = "permission"
+)
+
+// Recorder holds all the OpenTelemetry instruments for recording metrics
+type Recorder struct {
+	// Counters
+	resourcesProcessed metric.Int64Counter
+	resourcesDeleted   metric.Int64Counter
+	resourcesErrors    metric.Int64Counter
+
+	// Histograms for duration measurements
+	reconciliationDuration    metric.Float64Histogram
+	ttlProcessingDuration     metric.Float64Histogram
+	historyProcessingDuration metric.Float64Histogram
+	resourceAgeAtDeletion     metric.Float64Histogram
+
+	// UpDownCounters for gauge-like metrics
+	activeResourcesCount  metric.Int64UpDownCounter
+	pendingDeletionsCount metric.Int64UpDownCounter
+}
+
+var (
+	recorder *Recorder
+	once     sync.Once
+)
+
+// GetRecorder returns the singleton metrics recorder instance
+func GetRecorder() *Recorder {
+	once.Do(func() {
+		recorder = newRecorder()
+	})
+	return recorder
+}
+
+// newRecorder creates and initializes a new metrics recorder with all instruments
+func newRecorder() *Recorder {
+	meter := otel.Meter("tektoncd-pruner")
+
+	r := &Recorder{}
+
+	// Initialize counters
+	r.resourcesProcessed, _ = meter.Int64Counter(
+		MetricResourcesProcessed,
+		metric.WithDescription("Total number of Tekton resources processed by the pruner"),
+		metric.WithUnit("1"),
+	)
+
+	r.resourcesDeleted, _ = meter.Int64Counter(
+		MetricResourcesDeleted,
+		metric.WithDescription("Total number of Tekton resources deleted by the pruner"),
+		metric.WithUnit("1"),
+	)
+
+	r.resourcesErrors, _ = meter.Int64Counter(
+		MetricResourcesErrors,
+		metric.WithDescription("Total number of errors encountered while processing Tekton resources"),
+		metric.WithUnit("1"),
+	)
+
+	// Initialize histograms
+	r.reconciliationDuration, _ = meter.Float64Histogram(
+		MetricReconciliationDuration,
+		metric.WithDescription("Time spent in reconciliation loops"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+	)
+
+	r.ttlProcessingDuration, _ = meter.Float64Histogram(
+		MetricTTLProcessingDuration,
+		metric.WithDescription("Time spent processing TTL-based pruning"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+	)
+
+	r.historyProcessingDuration, _ = meter.Float64Histogram(
+		MetricHistoryProcessingDuration,
+		metric.WithDescription("Time spent processing history-based pruning"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+	)
+
+	r.resourceAgeAtDeletion, _ = meter.Float64Histogram(
+		MetricResourceAgeAtDeletion,
+		metric.WithDescription("Age of resources when they are deleted"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(
+			60, 300, 600, 1800, 3600, 7200, 14400, 28800, 86400, 172800, 345600, 604800,
+		), // 1m, 5m, 10m, 30m, 1h, 2h, 4h, 8h, 1d, 2d, 4d, 1w
+	)
+
+	// Initialize up-down counters
+	r.activeResourcesCount, _ = meter.Int64UpDownCounter(
+		MetricActiveResourcesCount,
+		metric.WithDescription("Current number of active Tekton resources being tracked"),
+		metric.WithUnit("1"),
+	)
+
+	r.pendingDeletionsCount, _ = meter.Int64UpDownCounter(
+		MetricPendingDeletionsCount,
+		metric.WithDescription("Current number of resources pending deletion"),
+		metric.WithUnit("1"),
+	)
+
+	return r
+}
+
+// Timer represents a duration measurement that can be recorded when stopped
+type Timer struct {
+	start    time.Time
+	recorder *Recorder
+	labels   []attribute.KeyValue
+}
+
+// NewTimer creates a new timer for measuring durations
+func (r *Recorder) NewTimer(labels ...attribute.KeyValue) *Timer {
+	return &Timer{
+		start:    time.Now(),
+		recorder: r,
+		labels:   labels,
+	}
+}
+
+// RecordReconciliationDuration records the duration since the timer was created
+func (t *Timer) RecordReconciliationDuration(ctx context.Context) {
+	duration := time.Since(t.start).Seconds()
+	t.recorder.reconciliationDuration.Record(ctx, duration, metric.WithAttributes(t.labels...))
+}
+
+// RecordTTLProcessingDuration records the duration since the timer was created
+func (t *Timer) RecordTTLProcessingDuration(ctx context.Context) {
+	duration := time.Since(t.start).Seconds()
+	t.recorder.ttlProcessingDuration.Record(ctx, duration, metric.WithAttributes(t.labels...))
+}
+
+// RecordHistoryProcessingDuration records the duration since the timer was created
+func (t *Timer) RecordHistoryProcessingDuration(ctx context.Context) {
+	duration := time.Since(t.start).Seconds()
+	t.recorder.historyProcessingDuration.Record(ctx, duration, metric.WithAttributes(t.labels...))
+}
+
+// RecordResourceProcessed increments the resources processed counter
+func (r *Recorder) RecordResourceProcessed(ctx context.Context, resourceType, namespace, status string) {
+	labels := []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+		attribute.String(LabelStatus, status),
+	}
+	r.resourcesProcessed.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+// RecordResourceDeleted increments the resources deleted counter and records age
+func (r *Recorder) RecordResourceDeleted(ctx context.Context, resourceType, namespace, operation string, resourceAge time.Duration) {
+	// Record deletion count
+	labels := []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+		attribute.String(LabelOperation, operation),
+	}
+	r.resourcesDeleted.Add(ctx, 1, metric.WithAttributes(labels...))
+
+	// Record resource age at deletion
+	r.resourceAgeAtDeletion.Record(ctx, resourceAge.Seconds(), metric.WithAttributes(labels...))
+}
+
+// RecordResourceError increments the resources error counter
+func (r *Recorder) RecordResourceError(ctx context.Context, resourceType, namespace, errorType, reason string) {
+	labels := []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+		attribute.String(LabelErrorType, errorType),
+		attribute.String(LabelReason, reason),
+	}
+	r.resourcesErrors.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+// UpdateActiveResourcesCount updates the active resources gauge
+func (r *Recorder) UpdateActiveResourcesCount(ctx context.Context, resourceType, namespace string, delta int64) {
+	labels := []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+	}
+	r.activeResourcesCount.Add(ctx, delta, metric.WithAttributes(labels...))
+}
+
+// UpdatePendingDeletionsCount updates the pending deletions gauge
+func (r *Recorder) UpdatePendingDeletionsCount(ctx context.Context, resourceType, namespace string, delta int64) {
+	labels := []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+	}
+	r.pendingDeletionsCount.Add(ctx, delta, metric.WithAttributes(labels...))
+}
+
+// Helper functions for creating common attribute sets
+
+// ResourceAttributes creates common resource-related attributes
+func ResourceAttributes(resourceType, namespace string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+	}
+}
+
+// ErrorAttributes creates error-related attributes
+func ErrorAttributes(resourceType, namespace, errorType, reason string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+		attribute.String(LabelErrorType, errorType),
+		attribute.String(LabelReason, reason),
+	}
+}
+
+// OperationAttributes creates operation-related attributes
+func OperationAttributes(resourceType, namespace, operation string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String(LabelResourceType, resourceType),
+		attribute.String(LabelNamespace, namespace),
+		attribute.String(LabelOperation, operation),
+	}
+}
+
+// ClassifyError determines the error type based on the error
+func ClassifyError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	switch {
+	case isAPIError(err):
+		return ErrorTypeAPI
+	case isTimeoutError(err):
+		return ErrorTypeTimeout
+	case isValidationError(err):
+		return ErrorTypeValidation
+	case isNotFoundError(err):
+		return ErrorTypeNotFound
+	case isPermissionError(err):
+		return ErrorTypePermission
+	default:
+		return ErrorTypeInternal
+	}
+}
+
+// Helper functions to classify errors (can be expanded based on actual error types)
+
+func isAPIError(err error) bool {
+	// Check for Kubernetes API errors
+	return errors.IsInternalError(err) || errors.IsServerTimeout(err) || errors.IsServiceUnavailable(err)
+}
+
+func isTimeoutError(err error) bool {
+	// Check for timeout-related errors
+	return errors.IsTimeout(err) || errors.IsServerTimeout(err)
+}
+
+func isValidationError(err error) bool {
+	// Check for validation errors
+	return errors.IsInvalid(err) || errors.IsBadRequest(err)
+}
+
+func isNotFoundError(err error) bool {
+	// Check for not found errors
+	return errors.IsNotFound(err)
+}
+
+func isPermissionError(err error) bool {
+	// Check for permission/authorization errors
+	return errors.IsForbidden(err) || errors.IsUnauthorized(err)
+}


### PR DESCRIPTION
# Changes

Co-authored  with : Cursor

This pull request introduces metrics explicitly for the Tekton Pruner controller. It includes detailed documentation for all exposed metrics, and enhances both the TTL and history-based pruning logic to record resource deletion events and errors, including resource age, operation type, and error classification. 

**Metrics Documentation:**

* Added a new `docs/metrics.md` file documenting all Tekton Pruner metrics, label values, PromQL queries, alerting rules, and dashboard recommendations for effective monitoring and troubleshooting.

**Metrics Recording in Pruning Logic:**

* In `pkg/config/history_limiter.go`, integrated metrics recording for resource deletion and error events in history-based pruning, including classification of error types and resource age at deletion.
* In `pkg/config/ttl_handler.go`, added metrics recording for TTL-based resource deletions and errors, capturing resource type, age, and operation context. [

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Run `make test lint` before submitting a PR
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```release-note
This PR enables metrics explicitly for tektoncd-pruner-controller across 4 categories.
- Ensures Native OpenTelemetry integration with Knative. Both the knative controller metrics and the Pruner functional metrics are exposed in same port 9090. 
- Rich labeling strategy for detailed observability
-  works out-of-the-box without additional configuartion
- Complete backward compatibility - no breaking changes
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
