### PR TITLE
Add function to correctly process resources count for pruner metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -25,19 +25,21 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	// Metric names
-	MetricResourcesProcessed        = "tektoncd_pruner_resources_processed_total"
-	MetricResourcesDeleted          = "tektoncd_pruner_resources_deleted_total"
-	MetricResourcesErrors           = "tektoncd_pruner_resources_errors_total"
-	MetricReconciliationDuration    = "tektoncd_pruner_reconciliation_duration_seconds"
-	MetricTTLProcessingDuration     = "tektoncd_pruner_ttl_processing_duration_seconds"
-	MetricHistoryProcessingDuration = "tektoncd_pruner_history_processing_duration_seconds"
-	MetricActiveResourcesCount      = "tektoncd_pruner_active_resources_count"
-	MetricPendingDeletionsCount     = "tektoncd_pruner_pending_deletions_count"
-	MetricResourceAgeAtDeletion     = "tektoncd_pruner_resource_age_at_deletion_seconds"
+	MetricResourcesProcessed        = "tekton_pruner_controller_resources_processed"
+	MetricReconciliationEvents      = "tekton_pruner_controller_reconciliation_events"
+	MetricResourcesDeleted          = "tekton_pruner_controller_resources_deleted"
+	MetricResourcesErrors           = "tekton_pruner_controller_resources_errors"
+	MetricReconciliationDuration    = "tekton_pruner_controller_reconciliation_duration"
+	MetricTTLProcessingDuration     = "tekton_pruner_controller_ttl_processing_duration"
+	MetricHistoryProcessingDuration = "tekton_pruner_controller_history_processing_duration"
+	MetricActiveResourcesCount      = "tekton_pruner_controller_active_resources"
+	MetricPendingDeletionsCount     = "tekton_pruner_controller_pending_deletions"
+	MetricResourceAgeAtDeletion     = "tekton_pruner_controller_resource_age_at_deletion"
 
 	// Label keys
 	LabelNamespace    = "namespace"
@@ -72,9 +74,10 @@ const (
 // Recorder holds all the OpenTelemetry instruments for recording metrics
 type Recorder struct {
 	// Counters
-	resourcesProcessed metric.Int64Counter
-	resourcesDeleted   metric.Int64Counter
-	resourcesErrors    metric.Int64Counter
+	resourcesProcessed   metric.Int64Counter
+	reconciliationEvents metric.Int64Counter
+	resourcesDeleted     metric.Int64Counter
+	resourcesErrors      metric.Int64Counter
 
 	// Histograms for duration measurements
 	reconciliationDuration    metric.Float64Histogram
@@ -85,6 +88,10 @@ type Recorder struct {
 	// UpDownCounters for gauge-like metrics
 	activeResourcesCount  metric.Int64UpDownCounter
 	pendingDeletionsCount metric.Int64UpDownCounter
+
+	// Cache for tracking unique resources
+	seenResources map[types.UID]bool
+	cacheMutex    sync.RWMutex
 }
 
 var (
@@ -106,10 +113,19 @@ func newRecorder() *Recorder {
 
 	r := &Recorder{}
 
+	// Initialize cache for unique resource tracking
+	r.seenResources = make(map[types.UID]bool)
+
 	// Initialize counters
 	r.resourcesProcessed, _ = meter.Int64Counter(
 		MetricResourcesProcessed,
 		metric.WithDescription("Total number of Tekton resources processed by the pruner"),
+		metric.WithUnit("1"),
+	)
+
+	r.reconciliationEvents, _ = meter.Int64Counter(
+		MetricReconciliationEvents,
+		metric.WithDescription("Total number of reconciliation events processed by the pruner"),
 		metric.WithUnit("1"),
 	)
 
@@ -206,14 +222,32 @@ func (t *Timer) RecordHistoryProcessingDuration(ctx context.Context) {
 	t.recorder.historyProcessingDuration.Record(ctx, duration, metric.WithAttributes(t.labels...))
 }
 
-// RecordResourceProcessed increments the resources processed counter
-func (r *Recorder) RecordResourceProcessed(ctx context.Context, resourceType, namespace, status string) {
+// RecordReconciliationEvent increments the reconciliation events counter
+func (r *Recorder) RecordReconciliationEvent(ctx context.Context, resourceType, namespace, status string) {
 	labels := []attribute.KeyValue{
 		attribute.String(LabelResourceType, resourceType),
 		attribute.String(LabelNamespace, namespace),
 		attribute.String(LabelStatus, status),
 	}
-	r.resourcesProcessed.Add(ctx, 1, metric.WithAttributes(labels...))
+	r.reconciliationEvents.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+// RecordResourceProcessed increments the unique resources counter if this UID hasn't been seen before
+func (r *Recorder) RecordResourceProcessed(ctx context.Context, resourceUID types.UID, resourceType, namespace, status string) {
+	r.cacheMutex.Lock()
+	defer r.cacheMutex.Unlock()
+
+	// Only count if we haven't seen this UID before
+	if !r.seenResources[resourceUID] {
+		r.seenResources[resourceUID] = true
+
+		labels := []attribute.KeyValue{
+			attribute.String(LabelResourceType, resourceType),
+			attribute.String(LabelNamespace, namespace),
+			attribute.String(LabelStatus, status),
+		}
+		r.resourcesProcessed.Add(ctx, 1, metric.WithAttributes(labels...))
+	}
 }
 
 // RecordResourceDeleted increments the resources deleted counter and records age

--- a/pkg/reconciler/pipelinerun/reconciler.go
+++ b/pkg/reconciler/pipelinerun/reconciler.go
@@ -45,7 +45,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *pipelinev1.PipelineR
 	// Record that we processed a resource
 	status := metrics.StatusSuccess
 	defer func() {
-		metricsRecorder.RecordResourceProcessed(ctx, metrics.ResourceTypePipelineRun, pr.Namespace, status)
+		// Record reconciliation event (every reconciliation)
+		metricsRecorder.RecordReconciliationEvent(ctx, metrics.ResourceTypePipelineRun, pr.Namespace, status)
+		// Record unique resource (only first time we see this UID)
+		metricsRecorder.RecordResourceProcessed(ctx, pr.UID, metrics.ResourceTypePipelineRun, pr.Namespace, status)
 	}()
 
 	// execute the history limiter earlier than the ttl handler

--- a/pkg/reconciler/taskrun/reconciler.go
+++ b/pkg/reconciler/taskrun/reconciler.go
@@ -54,7 +54,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *pipelinev1.TaskRun) 
 	// Record that we processed a resource
 	status := metrics.StatusSuccess
 	defer func() {
-		metricsRecorder.RecordResourceProcessed(ctx, metrics.ResourceTypeTaskRun, tr.Namespace, status)
+		// Record reconciliation event (every reconciliation)
+		metricsRecorder.RecordReconciliationEvent(ctx, metrics.ResourceTypeTaskRun, tr.Namespace, status)
+		// Record unique resource (only first time we see this UID)
+		metricsRecorder.RecordResourceProcessed(ctx, tr.UID, metrics.ResourceTypeTaskRun, tr.Namespace, status)
 	}()
 
 	// execute the history limiter earlier than the ttl handler


### PR DESCRIPTION
# Changes
Add function to correctly process resources for pruner metrics
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Run `make test lint` before submitting a PR
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes
```release-note
NONE
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
