### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-pruner-1-19-controller

### DIFF
--- a/.konflux/dockerfiles/controller.Dockerfile
+++ b/.konflux/dockerfiles/controller.Dockerfile
@@ -20,7 +20,8 @@ COPY --from=builder /tmp/controller ${CONTROLLER}
 
 LABEL \
       com.redhat.component="openshift-pipelines-tektoncd-pruner-controller-rhel9-container" \
-      name="openshift-pipelines/pipelines-tektoncd-pruner-controller-rhel9" \
+      name="openshift-pipelines/pipelines-pruner-controller-rhel9" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
       version=$VERSION \
       summary="Red Hat OpenShift Pipelines tektoncd-pruner Controller" \
       maintainer="pipelines-extcomm@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
